### PR TITLE
feat: Tauri IPC integration for audio capture (Issue #6)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,9 +7,43 @@ mod audio;
 mod vad;
 mod stt;
 
+use std::sync::Mutex;
 use tauri::{
     CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem,
+    State,
 };
+
+struct AppState {
+    is_recording: Mutex<bool>,
+}
+
+#[tauri::command]
+fn start_capture(state: State<AppState>) -> Result<String, String> {
+    let mut is_recording = state.is_recording.lock().map_err(|e| e.to_string())?;
+    if *is_recording {
+        return Ok("Already recording".to_string());
+    }
+    *is_recording = true;
+    // TODO: Initialize audio capture
+    Ok("Capture started".to_string())
+}
+
+#[tauri::command]
+fn stop_capture(state: State<AppState>) -> Result<String, String> {
+    let mut is_recording = state.is_recording.lock().map_err(|e| e.to_string())?;
+    if !*is_recording {
+        return Ok("Not recording".to_string());
+    }
+    *is_recording = false;
+    // TODO: Stop audio capture
+    Ok("Capture stopped".to_string())
+}
+
+#[tauri::command]
+fn get_capture_status(state: State<AppState>) -> Result<bool, String> {
+    let is_recording = state.is_recording.lock().map_err(|e| e.to_string())?;
+    Ok(*is_recording)
+}
 
 #[derive(Clone, serde::Serialize)]
 struct TranscriptionPayload {
@@ -58,6 +92,14 @@ fn main() {
             }
             _ => {}
         })
+        .manage(AppState {
+            is_recording: Mutex::new(false),
+        })
+        .invoke_handler(tauri::generate_handler![
+            start_capture,
+            stop_capture,
+            get_capture_status
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/tauri";
 import { writeText } from "@tauri-apps/api/clipboard";
 import { register, unregister } from "@tauri-apps/api/globalShortcut";
 
@@ -29,14 +30,27 @@ function App() {
       }
     );
 
+    // Get initial capture status
+    invoke<boolean>("get_capture_status")
+      .then((status) => setIsListening(status))
+      .catch(console.error);
+
     return () => {
       unlisten.then((fn) => fn());
     };
   }, []);
 
   const toggleListening = async () => {
-    setIsListening(!isListening);
-    // TODO: Send IPC command to start/stop audio capture
+    try {
+      if (!isListening) {
+        await invoke("start_capture");
+      } else {
+        await invoke("stop_capture");
+      }
+      setIsListening(!isListening);
+    } catch (error) {
+      console.error("Failed to toggle capture:", error);
+    }
   };
 
   const copyToClipboard = async () => {


### PR DESCRIPTION
## Issue
Closes #6

## Changes
- Add `start_capture`, `stop_capture`, `get_capture_status` Tauri commands in Rust
- Wire up frontend `toggleListening` to call IPC commands via `invoke()`
- Sync initial capture status on mount via `get_capture_status`

## Files changed
- `src-tauri/src/main.rs` — IPC command handlers + AppState
- `src/App.tsx` — wired up `invoke()` calls for start/stop/status

## Testing
- [ ] Test start/stop button in UI
- [ ] Verify status syncs on reload

## Notes
- Per project workflow: NO merge to `main` without Yvonne's approval
- Ready for BE audio capture module integration once Issue #2 lands