### PR TITLE
feat: settings page with model selector (Issue #7)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,18 +3,43 @@ import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/tauri";
 import { writeText } from "@tauri-apps/api/clipboard";
 
-
 interface TranscriptionEvent {
   text: string;
   is_final: boolean;
   language: string;
 }
 
+interface Settings {
+  model: string;
+  language: string;
+  hotkey: string;
+}
+
+const MODELS = [
+  { id: "tiny", label: "Tiny (39MB)", description: "Fastest, lowest accuracy" },
+  { id: "base", label: "Base (74MB)", description: "Good balance" },
+  { id: "small", label: "Small (244MB)", description: "Better accuracy" },
+  { id: "medium", label: "Medium (769MB)", description: "High accuracy" },
+  { id: "large", label: "Large (1550MB)", description: "Best accuracy" },
+];
+
+const LANGUAGES = [
+  { id: "auto", label: "Auto-detect" },
+  { id: "en", label: "English" },
+  { id: "zh", label: "中文" },
+];
+
 function App() {
   const [transcript, setTranscript] = useState<string>("");
   const [isListening, setIsListening] = useState(false);
   const [partialText, setPartialText] = useState<string>("");
   const [language, setLanguage] = useState<string>("auto");
+  const [showSettings, setShowSettings] = useState(false);
+  const [settings, setSettings] = useState<Settings>({
+    model: "base",
+    language: "auto",
+    hotkey: "CmdOrCtrl+Shift+S",
+  });
 
   useEffect(() => {
     const unlisten = listen<TranscriptionEvent>(
@@ -30,7 +55,6 @@ function App() {
       }
     );
 
-    // Get initial capture status
     invoke<boolean>("get_capture_status")
       .then((status) => setIsListening(status))
       .catch(console.error);
@@ -62,11 +86,90 @@ function App() {
     setPartialText("");
   };
 
+  const updateSetting = <K extends keyof Settings>(key: K, value: Settings[K]) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  };
+
   return (
     <div className="container">
+      {/* Settings Overlay */}
+      {showSettings && (
+        <div className="settings-overlay" onClick={() => setShowSettings(false)} />
+      )}
+
+      {/* Settings Panel */}
+      <div className={`settings-panel ${showSettings ? "open" : ""}`}>
+        <div className="settings-header">
+          <h2>⚙️ Settings</h2>
+          <button className="btn-close" onClick={() => setShowSettings(false)}>
+            ✕
+          </button>
+        </div>
+
+        <div className="settings-body">
+          {/* Model Selector */}
+          <section className="settings-section">
+            <h3>🎙️ STT Model</h3>
+            <p className="section-desc">
+              Larger models are slower but more accurate. Download models first.
+            </p>
+            <div className="model-list">
+              {MODELS.map((model) => (
+                <label key={model.id} className={`model-option ${settings.model === model.id ? "selected" : ""}`}>
+                  <input
+                    type="radio"
+                    name="model"
+                    value={model.id}
+                    checked={settings.model === model.id}
+                    onChange={() => updateSetting("model", model.id)}
+                  />
+                  <span className="model-label">{model.label}</span>
+                  <span className="model-desc">{model.description}</span>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          {/* Language */}
+          <section className="settings-section">
+            <h3>🌐 Language</h3>
+            <div className="lang-options">
+              {LANGUAGES.map((lang) => (
+                <button
+                  key={lang.id}
+                  className={`btn-lang ${settings.language === lang.id ? "active" : ""}`}
+                  onClick={() => updateSetting("language", lang.id)}
+                >
+                  {lang.label}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          {/* Hotkey */}
+          <section className="settings-section">
+            <h3>⌨️ Global Hotkey</h3>
+            <div className="hotkey-display">
+              <kbd>{settings.hotkey}</kbd>
+              <span>Toggle recording</span>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      {/* Main UI */}
       <header>
         <h1>🎙️ Noter</h1>
-        <span className="lang-badge">{language}</span>
+        <div className="header-actions">
+          <span className="lang-badge">{language}</span>
+          <button
+            className="btn-icon"
+            onClick={() => setShowSettings(true)}
+            title="Settings"
+          >
+            ⚙️
+          </button>
+        </div>
       </header>
 
       <main>

--- a/src/styles.css
+++ b/src/styles.css
@@ -120,3 +120,177 @@ button {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.7; }
 }
+
+/* Header actions */
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-icon {
+  background: transparent;
+  padding: 6px 10px;
+  font-size: 1.1rem;
+  border-radius: 8px;
+}
+
+.btn-icon:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* Settings Panel */
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 99;
+}
+
+.settings-panel {
+  position: fixed;
+  top: 0;
+  right: -360px;
+  width: 360px;
+  height: 100vh;
+  background: var(--bg-secondary);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  transition: right 0.3s ease;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.settings-panel.open {
+  right: 0;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.settings-header h2 {
+  font-size: 1.1rem;
+}
+
+.btn-close {
+  background: transparent;
+  padding: 4px 10px;
+  font-size: 1rem;
+  color: var(--text-secondary);
+}
+
+.btn-close:hover {
+  color: var(--text-primary);
+}
+
+.settings-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.settings-section {
+  margin-bottom: 28px;
+}
+
+.settings-section h3 {
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+  color: var(--text-primary);
+}
+
+.section-desc {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+/* Model list */
+.model-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.model-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.15s;
+}
+
+.model-option:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.model-option.selected {
+  border-color: var(--accent);
+  background: rgba(233, 69, 96, 0.1);
+}
+
+.model-option input[type="radio"] {
+  accent-color: var(--accent);
+}
+
+.model-label {
+  font-size: 0.85rem;
+  flex: 1;
+}
+
+.model-desc {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+/* Language options */
+.lang-options {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.btn-lang {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary);
+  padding: 8px 16px;
+  font-size: 0.85rem;
+}
+
+.btn-lang:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.btn-lang.active {
+  background: var(--accent);
+  color: white;
+}
+
+/* Hotkey */
+.hotkey-display {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  margin-top: 8px;
+}
+
+kbd {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-family: monospace;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}


### PR DESCRIPTION
## Issue
Closes #7

## Changes
- Slide-out settings panel (triggered by ⚙️ gear icon)
- **Model selector** — tiny/base/small/medium/large whisper models with radio buttons
- **Language picker** — EN / 中文 / Auto-detect buttons
- **Hotkey display** — shows current global shortcut (read-only)
- Settings state managed locally; ready for IPC persistence

## Files changed
- `src/App.tsx` — added settings panel, state, model/language controls
- `src/styles.css` — settings panel slide-in animation, radio/card styles

## Testing
- [ ] Click ⚙️ gear icon → settings panel slides in
- [ ] Select a model → radio button highlights
- [ ] Select language → button highlights
- [ ] Click overlay or ✕ → panel closes