### PR TITLE
fix(ci): revert Linux runner to ubuntu-22.04 with webkit2gtk-4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           path: src-tauri/target/release/bundle/dmg/*.dmg
 
   build-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm


### PR DESCRIPTION
## Problem

Tauri v1 requires **webkit2gtk 4.0**, not 4.1.

- ubuntu-24.04 ships with webkit2gtk **4.1** → **incompatible**
- ubuntu-22.04 ships with webkit2gtk **4.0** → **compatible**

Previous attempts on ubuntu-24.04 failed with:


Because ubuntu-24.04's webkit packages are 4.1, not 4.0.

## Fix

- Revert  → 
- Keep  + 

macOS + Windows builds have been passing throughout. This should make Linux pass too.

## CI Status
| Platform | Before | After |
|----------|--------|--------|
| macOS | ✅ | ✅ |
| Windows | ✅ | ✅ |
| Linux | ❌ | 🔄 expected ✅ |

Closes: restores full 3-platform CI pipeline.