### PR TITLE
fix(ci): ubuntu-20.04 + webkit2gtk-4.0 (fixes Linux build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           path: src-tauri/target/release/bundle/dmg/*.dmg
 
   build-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           path: src-tauri/target/release/bundle/dmg/*.dmg
 
   build-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm


### PR DESCRIPTION
## Root Cause

Tauri v1 () requires **webkit2gtk 4.0**.
- ubuntu-22.04's jammy-updates → webkit2gtk **4.1** ❌
- ubuntu-24.04 → webkit2gtk **4.1** ❌
- ubuntu-20.04 (focal) → webkit2gtk **4.0** ✅

All previous attempts failed because the runner's OS was bumped to webkit2gtk 4.1.

## Fix

- Change Linux runner:  → 
- Packages:  +  (ubuntu-20.04 has these)

## CI Status

| Platform | Status |
|----------|--------|
| macOS | ✅ |
| Windows | ✅ |
| Linux (ubuntu-20.04) | 🔄 expecting ✅ |

This should finally make the Linux build pass.