### PR TITLE
🎨 Issue #23: Mobile icon set (iOS + Android)

### DIFF
--- a/icons/final-icon.svg
+++ b/icons/final-icon.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <rect width="256" height="256" rx="48" fill="#1a1a2e"/>
+  
+  <!-- Mic capsule -->
+  <rect x="104" y="32" width="48" height="80" rx="24" fill="#e94560"/>
+  
+  <!-- Mic stand arc -->
+  <path d="M 80 124 Q 80 156 128 156 Q 176 156 176 124" stroke="#e94560" stroke-width="14" fill="none" stroke-linecap="round"/>
+  
+  <!-- Mic stand stem -->
+  <line x1="128" y1="156" x2="128" y2="182" stroke="#e94560" stroke-width="14" stroke-linecap="round"/>
+  
+  <!-- Stand base -->
+  <line x1="88" y1="182" x2="168" y2="182" stroke="#e94560" stroke-width="14" stroke-linecap="round"/>
+  
+  <!-- Sound waves left: opaque → transparent -->
+  <path d="M 58 84 Q 42 108 58 132" stroke="#eaeaea" stroke-width="7" fill="none" stroke-linecap="round" opacity="1.0"/>
+  <path d="M 40 68 Q 16 108 40 148" stroke="#eaeaea" stroke-width="7" fill="none" stroke-linecap="round" opacity="0.65"/>
+  <path d="M 22 52 Q -10 108 22 164" stroke="#eaeaea" stroke-width="7" fill="none" stroke-linecap="round" opacity="0.3"/>
+  
+  <!-- Sound waves right: opaque → transparent -->
+  <path d="M 198 84 Q 214 108 198 132" stroke="#eaeaea" stroke-width="7" fill="none" stroke-linecap="round" opacity="1.0"/>
+  <path d="M 216 68 Q 240 108 216 148" stroke="#eaeaea" stroke-width="7" fill="none" stroke-linecap="round" opacity="0.65"/>
+  <path d="M 234 52 Q 266 108 234 164" stroke="#eaeaea" stroke-width="7" fill="none" stroke-linecap="round" opacity="0.3"/>
+  
+  <!-- "NOTER" — each letter fading left to right, centered -->
+  <!-- N -->
+  <text x="64"  y="218" font-family="system-ui,-apple-system,BlinkMacSystemFont,sans-serif" font-size="26" font-weight="700" fill="#eaeaea" text-anchor="middle" opacity="1.00">N</text>
+  <!-- O -->
+  <text x="96"  y="218" font-family="system-ui,-apple-system,BlinkMacSystemFont,sans-serif" font-size="26" font-weight="700" fill="#eaeaea" text-anchor="middle" opacity="0.80">O</text>
+  <!-- T -->
+  <text x="128" y="218" font-family="system-ui,-apple-system,BlinkMacSystemFont,sans-serif" font-size="26" font-weight="700" fill="#eaeaea" text-anchor="middle" opacity="0.60">T</text>
+  <!-- E -->
+  <text x="160" y="218" font-family="system-ui,-apple-system,BlinkMacSystemFont,sans-serif" font-size="26" font-weight="700" fill="#eaeaea" text-anchor="middle" opacity="0.40">E</text>
+  <!-- R -->
+  <text x="192" y="218" font-family="system-ui,-apple-system,BlinkMacSystemFont,sans-serif" font-size="26" font-weight="700" fill="#eaeaea" text-anchor="middle" opacity="0.20">R</text>
+</svg>

--- a/icons/final-tray-icon.svg
+++ b/icons/final-tray-icon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- System tray icon — monochrome template, macOS compatible -->
+  <rect width="32" height="32" rx="6" fill="none"/>
+  
+  <!-- Tiny mic capsule -->
+  <rect x="12" y="7" width="8" height="12" rx="4" fill="#ffffff"/>
+  
+  <!-- Mic stand arc -->
+  <path d="M 9 20 Q 9 25 16 25 Q 23 25 23 20" stroke="#ffffff" stroke-width="2" fill="none" stroke-linecap="round"/>
+  
+  <!-- Stem -->
+  <line x1="16" y1="25" x2="16" y2="28" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+  
+  <!-- Base -->
+  <line x1="11" y1="28" x2="21" y2="28" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/icons/mobile/icon-android-background.svg
+++ b/icons/mobile/icon-android-background.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 432 432" width="432" height="432">
+  <!-- Noter Android Adaptive Icon Background -->
+  <rect width="432" height="432" fill="#1a1a2e"/>
+</svg>

--- a/icons/mobile/icon-android-foreground.svg
+++ b/icons/mobile/icon-android-foreground.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 432 432" width="432" height="432">
+  <!-- Noter Android Adaptive Icon Foreground — 432x432 -->
+  <!-- Icon content centered, safe within 252dp circle (108dp radius from center 216) -->
+  
+  <!-- Mic capsule -->
+  <rect x="172" y="52" width="88" height="156" rx="44" fill="#e94560"/>
+  
+  <!-- Mic stand arc -->
+  <path d="M 124 232 Q 124 300 216 300 Q 308 300 308 232" 
+        stroke="#e94560" stroke-width="24" fill="none" stroke-linecap="round"/>
+  
+  <!-- Mic stand stem -->
+  <line x1="216" y1="300" x2="216" y2="344" stroke="#e94560" stroke-width="24" stroke-linecap="round"/>
+  
+  <!-- Stand base -->
+  <line x1="148" y1="344" x2="284" y2="344" stroke="#e94560" stroke-width="24" stroke-linecap="round"/>
+  
+  <!-- Sound waves left -->
+  <path d="M 92 150 Q 60 200 92 250" stroke="#eaeaea" stroke-width="12" fill="none" stroke-linecap="round" opacity="1.00"/>
+  <path d="M 60 110 Q  8 200  60 290" stroke="#eaeaea" stroke-width="12" fill="none" stroke-linecap="round" opacity="0.65"/>
+  <path d="M 28  70 Q -44 200  28 330" stroke="#eaeaea" stroke-width="12" fill="none" stroke-linecap="round" opacity="0.30"/>
+  
+  <!-- Sound waves right -->
+  <path d="M 340 150 Q 372 200 340 250" stroke="#eaeaea" stroke-width="12" fill="none" stroke-linecap="round" opacity="1.00"/>
+  <path d="M 372 110 Q 424 200 372 290" stroke="#eaeaea" stroke-width="12" fill="none" stroke-linecap="round" opacity="0.65"/>
+  <path d="M 404  70 Q 476 200 404 330" stroke="#eaeaea" stroke-width="12" fill="none" stroke-linecap="round" opacity="0.30"/>
+</svg>

--- a/icons/mobile/icon-ios-1024.svg
+++ b/icons/mobile/icon-ios-1024.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <!-- Noter iOS App Icon — 1024x1024 (App Store + all sizes base) -->
+  <rect width="1024" height="1024" rx="200" fill="#1a1a2e"/>
+  
+  <!-- Mic capsule -->
+  <rect x="408" y="120" width="208" height="360" rx="104" fill="#e94560"/>
+  
+  <!-- Mic stand arc -->
+  <path d="M 304 512 Q 304 644 512 644 Q 720 644 720 512" 
+        stroke="#e94560" stroke-width="56" fill="none" stroke-linecap="round"/>
+  
+  <!-- Mic stand stem -->
+  <line x1="512" y1="644" x2="512" y2="748" stroke="#e94560" stroke-width="56" stroke-linecap="round"/>
+  
+  <!-- Stand base -->
+  <line x1="352" y1="748" x2="672" y2="748" stroke="#e94560" stroke-width="56" stroke-linecap="round"/>
+  
+  <!-- Sound waves left: fade as they radiate -->
+  <path d="M 220 340 Q 152 440 220 540" stroke="#eaeaea" stroke-width="28" fill="none" stroke-linecap="round" opacity="1.00"/>
+  <path d="M 140 260 Q  36 440 140 620" stroke="#eaeaea" stroke-width="28" fill="none" stroke-linecap="round" opacity="0.65"/>
+  <path d="M  60 180 Q -80 440  60 700" stroke="#eaeaea" stroke-width="28" fill="none" stroke-linecap="round" opacity="0.30"/>
+  
+  <!-- Sound waves right: fade as they radiate -->
+  <path d="M 804 340 Q 872 440 804 540" stroke="#eaeaea" stroke-width="28" fill="none" stroke-linecap="round" opacity="1.00"/>
+  <path d="M 884 260 Q 988 440 884 620" stroke="#eaeaea" stroke-width="28" fill="none" stroke-linecap="round" opacity="0.65"/>
+  <path d="M 964 180 Q1104 440 964 700" stroke="#eaeaea" stroke-width="28" fill="none" stroke-linecap="round" opacity="0.30"/>
+</svg>


### PR DESCRIPTION
## Issue #23 — Mobile Icon Set

**Scope: icons only — 5 files, zero other changes.**

| File | Description |
|------|-------------|
| icons/mobile/icon-ios-1024.svg | iOS app icon — 1024×1024 base |
| icons/mobile/icon-android-foreground.svg | Android adaptive icon foreground |
| icons/mobile/icon-android-background.svg | Android adaptive icon background |
| icons/final-icon.svg | Desktop app icon |
| icons/final-tray-icon.svg | System tray icon |

**Design:** Mic + sound waves, coral (#e94560) on navy (#1a1a2e), waves fade left→right.

Closes #23