### PR TITLE
fix(ci): add develop branch to workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Problem
`release.yml` only triggers on `main` push/PR — every push to `develop` causes a workflow failure because the trigger doesn't match.

## Fix
Add `develop` to the push and pull_request trigger branches.

Quick fix, no logic changes.